### PR TITLE
chore: remove logo from sample healthcert

### DIFF
--- a/src/templates/healthcert/fixtures/sample.ts
+++ b/src/templates/healthcert/fixtures/sample.ts
@@ -172,6 +172,5 @@ export const healthCertSample: HealthCertDocument = {
     url:
       "https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fgallery.openattestation.com%2Fstatic%2Fdocuments%2Fhealthcerts-memo-notarised.json%22%2C%22permittedActions%22%3A%5B%22VIEW%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.opencerts.io%22%7D%7D"
   },
-  logo:
-    ""
+  logo: ""
 };

--- a/src/templates/healthcert/healthCertTemplate.tsx
+++ b/src/templates/healthcert/healthCertTemplate.tsx
@@ -165,9 +165,7 @@ export const HealthCertTemplate: FunctionComponent<TemplateProps<HealthCertDocum
   return (
     <Page className={className}>
       <Background />
-      { document.logo &&
-        <Logo src={document.logo} alt="healthcare provider logo" />
-      }      
+      {document.logo && <Logo src={document.logo} alt="healthcare provider logo" />}
       <Title>MEMO ON COVID-19 REAL TIME</Title>
       <SubTitle>RT-PCR SWAB TEST RESULT</SubTitle>
       <Patient>


### PR DESCRIPTION
upper management wants to remove the Raffles Medical Logo from the sample healthcert, as they do not want free advertisement for Raffles Medical.

I made the logo property of the sample json doc empty, and then conditionally render from there.