### PR TITLE
Use the correct timezone indicator instead of hardcoding display to GMT+8

### DIFF
--- a/src/templates/healthcert/memo/parseInfo.ts
+++ b/src/templates/healthcert/memo/parseInfo.ts
@@ -21,10 +21,11 @@ type ParsedInfo = Pick<
   | "testResult"
 >;
 
-const DATE_LOCALE = "en-sg"; // let's force the display of dates using sg locals
+const SG_LOCALE = "en-sg";
 
 const getDateTime = (dateString: string | undefined): string => {
-  return dateString ? new Date(dateString).toLocaleString(DATE_LOCALE) + " GMT+08:00" : "";
+  // locale is fixed to always show day/month/year, in this order
+  return dateString ? new Date(dateString).toLocaleString(SG_LOCALE, { timeZoneName: "short" }) : "";
 };
 
 export const getTestResult = (observation: healthcert.Patient): string => {


### PR DESCRIPTION
The collection date is currently correctly converted to the timezone of the browser viewing the page, but the timezone display is hardcoded to GMT+8, causing confusion for anyone not in Singapore.

* [x] Change date formatting to also include the timezone of the current locale