### PR TITLE
Lock version of countries and nationality npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "@govtechsg/oa-schemata": "^1.8.0",
     "@hot-loader/react-dom": "^16.11.0",
     "debug": "4.1.1",
-    "i18n-iso-countries": "^6.7.0",
-    "i18n-nationality": "^1.1.1",
+    "i18n-iso-countries": "6.7.0",
+    "i18n-nationality": "1.1.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-hot-loader": "^4.12.18"


### PR DESCRIPTION
- prevent changes to country names showing up on our service without us knowing, which could spark international incidents