### PR TITLE
fix: birthdate displayed in wrong timezone

### DIFF
--- a/src/templates/healthcert/healthCertTemplate.tsx
+++ b/src/templates/healthcert/healthCertTemplate.tsx
@@ -9,6 +9,8 @@ import { MemoSection } from "./memo/memoSection";
 import { Page, Background, Logo, QrCodeContainer } from "./styled-components";
 import { extractInfo } from "./memo/parseInfo";
 
+const SG_LOCALE = "en-sg";
+
 const isNric = (value: any): value is healthcert.Identifier => value?.type?.text === "NRIC";
 
 export const HealthCertTemplate: FunctionComponent<TemplateProps<HealthCertDocument> & {
@@ -25,8 +27,13 @@ export const HealthCertTemplate: FunctionComponent<TemplateProps<HealthCertDocum
       extension => extension.url === "http://hl7.org/fhir/StructureDefinition/patient-nationality"
     )?.code?.text || "";
   let birthdate = patient?.birthDate;
-  if (birthdate != null) {
-    birthdate = new Date(birthdate).toLocaleString(undefined, {
+  if (birthdate) {
+    birthdate = new Date(birthdate).toLocaleString(SG_LOCALE, {
+      /**
+       * Should not respect browser locale but rather,
+       * force "UTC" timezone because time (in birthdate) is always going to be ...T00:00:00.000Z
+       **/
+      timeZone: "UTC",
       month: "long",
       day: "numeric",
       year: "numeric"


### PR DESCRIPTION
**Context**
| Code | Screenshot |
| ----- | ----- |
| ![birthday-timezone-issue-code](https://user-images.githubusercontent.com/37650399/120332240-21014300-c321-11eb-9597-55a9201dd519.png) | ![birthdate-timezone-issue](https://user-images.githubusercontent.com/37650399/120330644-9835d780-c31f-11eb-9ea4-cacfe74aa3b4.png) |

- **BEWARE**: `new Date("1990-01-01")` is dangerous! ([Source](https://css-tricks.com/everything-you-need-to-know-about-date-in-javascript/#the-date-string-method))
- Since birthdate does not have a time, the initialised date is always going to be `...T00:00:00.000Z`
- If browser locale/timezone is in the negative range (i.e. GMT -1 to GMT -12), date will be equivalent to previous day (-1)
- Any timezones in the negative range will experience this issue

**Fix**
| Code | Screenshot |
| ----- | ----- |
| ![birthdate-timezone-fix-code](https://user-images.githubusercontent.com/37650399/120333400-39be2880-c322-11eb-91d5-f42bc2fe5ddf.png) | ![birthdate-timezone-fix](https://user-images.githubusercontent.com/37650399/120333362-32971a80-c322-11eb-9ec2-4845ff602b94.png) |

- Should not respect browser locale but rather, force "UTC" timezone because time (in birthdate) is always going to be `...T00:00:00.000Z`
- Since memo is also printed in `en-SG` locale, will standardise the format printed in birthdate field as well