### PR TITLE
fix: vacc certs date

### DIFF
--- a/src/templates/healthcert/healthCertTemplate.tsx
+++ b/src/templates/healthcert/healthCertTemplate.tsx
@@ -30,7 +30,7 @@ export const HealthCertTemplate: FunctionComponent<TemplateProps<HealthCertDocum
   if (birthdate) {
     birthdate = new Date(birthdate).toLocaleString(SG_LOCALE, {
       /**
-       * Should not respect browser locale but rather,
+       * Should not respect browser timezone but rather,
        * force "UTC" timezone because time (in birthdate) is always going to be ...T00:00:00.000Z
        **/
       timeZone: "UTC",

--- a/src/templates/healthcert/vaccinationCertTemplate.tsx
+++ b/src/templates/healthcert/vaccinationCertTemplate.tsx
@@ -6,7 +6,16 @@ import { healthcert } from "@govtechsg/oa-schemata";
 import { VaccinationMemoSection, SimpleImmunizationObject } from "./memo/memoSection";
 import { Page, Background, Logo, QrCodeContainer } from "./styled-components";
 
-const dateFormatter = new Intl.DateTimeFormat("en-SG", { day: "numeric", month: "long", year: "numeric" });
+const dateFormatter = new Intl.DateTimeFormat("en-SG", {
+  /**
+   * Should not respect browser timezone but rather,
+   * force "UTC" timezone because dates in vacc certs do not have time
+   **/
+  timeZone: "UTC",
+  month: "long",
+  day: "numeric",
+  year: "numeric"
+});
 const formatDate = (iso?: string): string => (iso ? dateFormatter.format(new Date(iso)) : "N/A");
 const isNric = (value: healthcert.Identifier): boolean => typeof value.type !== "string" && value.type.text === "NRIC";
 
@@ -42,7 +51,7 @@ export const VaccinationCertTemplate: FunctionComponent<TemplateProps<NotarisedH
     patient?.extension?.find(
       extension => extension.url === "http://hl7.org/fhir/StructureDefinition/patient-nationality"
     )?.code.text || "";
-  const patientBirthDate = formatDate(patient.birthDate || "");
+  const patientBirthDate = formatDate(patient.birthDate || "") + " = " + patient.birthDate;
   const effectiveDate = formatDate(recommendation?.recommendation[0].dateCriterion[0].value);
 
   const url = (document.notarisationMetadata as any)?.url;


### PR DESCRIPTION
Implement the same fixes for vacc certs as #52:
- Force "UTC" timezone because dates in vacc certs do not have time