### PR TITLE
Bug-180174330: Fix large empty space when printing Vaccination HealthCert

### DIFF
--- a/src/templates/healthcert/memo/vacV1Memo.tsx
+++ b/src/templates/healthcert/memo/vacV1Memo.tsx
@@ -10,7 +10,6 @@ import {
   FirstCol,
   SecondCol,
   ResultSection,
-  StyledMemoSection,
   TravellerInfoSection,
   Bold,
   QrCodeContainerWithBorder,
@@ -96,7 +95,7 @@ export const MemoSection: React.FC<{
   );
   const groupedVaccineCode = Object.keys(groupedImmunizations);
   return (
-    <StyledMemoSection>
+    <>
       <Title>Vaccination Certificate</Title>
       <PatientDetails>
         <Row>
@@ -160,6 +159,6 @@ export const MemoSection: React.FC<{
         ))
       )}
       {memoResultSection}
-    </StyledMemoSection>
+    </>
   );
 };

--- a/src/templates/healthcert/styled-components.tsx
+++ b/src/templates/healthcert/styled-components.tsx
@@ -67,6 +67,7 @@ export const Title = styled.h1`
 export const PatientDetails = styled.section``;
 export const ImmunizationDetails = styled.section`
   padding-top: 20px;
+  page-break-inside: avoid;
 `;
 export const Row = styled.div`
   display: flex;
@@ -194,6 +195,7 @@ export const QrRowCenter = styled.div`
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
+  page-break-inside: avoid;
 `;
 
 export const QrColCenter = styled.div`


### PR DESCRIPTION
**What does this PR do?**
- remove `avoid page break` in  whole vaccine certificate content
- add `avoid page break` in between `Dose 1` , `Dose 2`, `Dose 3` content
- add `avoid page break` in between individual offline QR dose type.