### PR TITLE
Bg-180174330 Fix large empty space when printing Vaccination HealthCert

### DIFF
--- a/src/templates/healthcert/memo/vacV1Memo.tsx
+++ b/src/templates/healthcert/memo/vacV1Memo.tsx
@@ -10,7 +10,6 @@ import {
   FirstCol,
   SecondCol,
   ResultSection,
-  StyledMemoSection,
   TravellerInfoSection,
   Bold,
   QrCodeContainerWithBorder,
@@ -96,7 +95,7 @@ export const MemoSection: React.FC<{
   );
   const groupedVaccineCode = Object.keys(groupedImmunizations);
   return (
-    <StyledMemoSection>
+    <>
       <Title>Vaccination Certificate</Title>
       <PatientDetails>
         <Row>
@@ -160,6 +159,6 @@ export const MemoSection: React.FC<{
         ))
       )}
       {memoResultSection}
-    </StyledMemoSection>
+    </>
   );
 };

--- a/src/templates/healthcert/parsers/vacHealthCertV1/generateMultiQrSection.tsx
+++ b/src/templates/healthcert/parsers/vacHealthCertV1/generateMultiQrSection.tsx
@@ -9,6 +9,8 @@ import {
   ResultSection,
   QrRowCenter,
   QrColCenter,
+  QrTitle,
+  StyledMemoSection,
 } from "../../styled-components";
 interface GroupedOfflineQr {
   manufacturer: string;
@@ -19,9 +21,9 @@ const OfflineQrGroup: React.FC<{
   groupedOfflineQr: GroupedOfflineQr;
 }> = ({ groupedOfflineQr }) => {
   return (
-    <>
+    <StyledMemoSection>
+      <QrTitle>{groupedOfflineQr.manufacturer}</QrTitle>
       <QrRowCenter>
-        <Bold>{groupedOfflineQr.manufacturer}</Bold>
         {groupedOfflineQr.signedEuHealthCerts.map((signedEuHealthCert, i) => (
           <QrColCenter key={i}>
             <QrCodeContainerWithBorder key={i}>
@@ -32,7 +34,7 @@ const OfflineQrGroup: React.FC<{
         ))}
       </QrRowCenter>
       <br />
-    </>
+    </StyledMemoSection>
   );
 };
 

--- a/src/templates/healthcert/styled-components.tsx
+++ b/src/templates/healthcert/styled-components.tsx
@@ -67,6 +67,7 @@ export const Title = styled.h1`
 export const PatientDetails = styled.section``;
 export const ImmunizationDetails = styled.section`
   padding-top: 20px;
+  page-break-inside: avoid;
 `;
 export const Row = styled.div`
   display: flex;
@@ -200,4 +201,9 @@ export const QrColCenter = styled.div`
   text-align: center;
   margin: 10px;
   padding: 0px 30px;
+`;
+
+export const QrTitle = styled.p`
+  font-weight: bold;
+  text-align: center;
 `;


### PR DESCRIPTION
**What does this PR do?**
- remove `avoid page break` in  whole vaccine certificate content
- add `avoid page break` in between `Dose 1` , `Dose 2`, `Dose 3` content
- add `avoid page break` in between individual offline QR dose type content.