### PR TITLE
chore: 183333837 hardcode addition of qr expiry date for pdt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,6 +4934,11 @@
         "typesafe-actions": "^5.1.0"
       },
       "dependencies": {
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -24449,11 +24454,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
-    },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/src/templates/healthcert/parsers/pdtHealthCertV2/generateMultiQrSection.tsx
+++ b/src/templates/healthcert/parsers/pdtHealthCertV2/generateMultiQrSection.tsx
@@ -36,13 +36,30 @@ export const generateMultiQrSection = (
   const signedEuHealthCert =
     document.notarisationMetadata.signedEuHealthCerts?.[0];
 
-  let expiryDateTime = "";
-  if (signedEuHealthCert?.expiryDateTime) {
-    expiryDateTime = isoToDateOnlyString(signedEuHealthCert.expiryDateTime, {
+  // Date that transient storage was increased to 60 days: https://github.com/Notarise-gov-sg/api-transient-storage/actions/runs/3087216953
+  const DATE_OF_INCREASE = new Date("2022-09-23T11:45:00.000+08:00");
+
+  const endorsedDate = new Date(document.notarisationMetadata.notarisedOn);
+  let qrExpiryDateString = "";
+
+  // FIXME: Find a better way to obtain QR TTL instead of hardcoded endorsement date + 60 days
+  if (endorsedDate > DATE_OF_INCREASE) {
+    const expiryDate = new Date(endorsedDate);
+    expiryDate.setDate(expiryDate.getDate() + 60);
+    qrExpiryDateString = isoToDateOnlyString(expiryDate.toISOString(), {
       day: "numeric",
       month: "short",
       year: "numeric",
     });
+  } else if (signedEuHealthCert?.expiryDateTime) {
+    qrExpiryDateString = isoToDateOnlyString(
+      signedEuHealthCert.expiryDateTime,
+      {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      }
+    );
   }
 
   return (
@@ -57,13 +74,13 @@ export const generateMultiQrSection = (
         <br />
         The QR code used for verification is based on your{" "}
         <u>destination country</u>.
-        {expiryDateTime && (
+        {qrExpiryDateString && (
           <>
             <br />
             <br />
             The <u>QR codes</u> in the PDT HealthCert are active until{" "}
-            <b>{expiryDateTime}</b>. Please note this is not the expiry date of
-            your PDT records or PDT status.
+            <b>{qrExpiryDateString}</b>. Please note this is not the expiry date
+            of your PDT records or PDT status.
           </>
         )}
       </TravellerInfoSection>


### PR DESCRIPTION
## Context
- Transient storage for PDTs was increased to 60 days: Notarise-gov-sg/api-transient-storage/pull/146
- QR expiry date is currently obtained from the expiry date of EU DCC QR (i.e. `signedEuHealthCert.expiryDateTime`) which remains at 7 days validity

## What does this PR do?
- Instead of using EU DCC QR expiry date, calculate the new expiry date by adding 60 days to the endorsed date (i.e. `document.notarisationMetadata.notarisedOn`)
- This is only done for documents issued after `2022-09-23T11:45:00.000+08:00` (Deployment datetime: https://github.com/Notarise-gov-sg/api-transient-storage/actions/runs/3087216953)
- Documents issued before this date will continue to utilise the EU DCC QR expiry date

## Ideal scenario
- Online QR expiry date (or `TTL`) should be defined inside the OA document under `notarisationMetadata`
- This is currently not possible as the `TTL` is only produced [after a signed OA document is uploaded](https://github.com/Notarise-gov-sg/api-notarise-healthcerts/blob/9eab01b31a9dc202f54b773dd6f19c2f135d6c38/src/functionHandlers/notarisePdt/v2/notarisePdt.ts#L60) to transient storage