### PR TITLE
Fix the PDT offline QR code for being too big 

### DIFF
--- a/src/templates/healthcert/parsers/pdtHealthCertV2/generateMultiQrSection.tsx
+++ b/src/templates/healthcert/parsers/pdtHealthCertV2/generateMultiQrSection.tsx
@@ -108,7 +108,7 @@ export const generateMultiQrSection = (
         <QrRowCenter>
           <EUDCCOfflineQrCodeContainer>
             <EUDCCTag>OFFLINE QR (EU DCC)</EUDCCTag>
-            <QrCode value={signedEuHealthCert.qr} />
+            <QrCode value={signedEuHealthCert.qr} scale={2.5} />
           </EUDCCOfflineQrCodeContainer>
         </QrRowCenter>
       )}


### PR DESCRIPTION
Offlined QR was too big when viewed in mobile,  causing QR to run out of bounds on parent container

Fix
- adding a reduced scaling of 2.5 for offline QR in PDT