### PR TITLE
fix: 183425411 responsive qr code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,6 +4934,11 @@
         "typesafe-actions": "^5.1.0"
       },
       "dependencies": {
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -24450,11 +24455,6 @@
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
     },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -31140,7 +31140,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/src/components/qrcode.tsx
+++ b/src/components/qrcode.tsx
@@ -30,7 +30,7 @@ export const QrCode = ({
   useEffect(() => {
     if (!canvasRef.current || !value) return;
 
-    const options: QRCodeRenderersOptions = { scale: 2, ...rest };
+    const options: QRCodeRenderersOptions = { scale: 3, ...rest };
     if (qrWidth) options.width = qrWidth;
 
     qrcode.toCanvas(

--- a/src/components/qrcode.tsx
+++ b/src/components/qrcode.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement, useEffect, useRef } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import qrcode, { QRCodeRenderersOptions } from "qrcode";
+
+import { useWindowDimensions } from "../util/useWindowDimensions";
 
 interface QrCodeProps {
   value: string;
@@ -10,19 +12,34 @@ export const QrCode = ({
   value,
   hasBorder,
   ...rest
-}: QrCodeProps & QRCodeRenderersOptions): ReactElement => {
+}: QrCodeProps & Omit<QRCodeRenderersOptions, "width">): ReactElement => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [qrWidth, setQrWidth] = useState<number>();
+  const { width } = useWindowDimensions();
+
+  /* A hack to make QR code responsive when viewport is <300px */
+  useEffect(() => {
+    if (width <= 300) {
+      const eightyPercentWidth = Math.floor(width * 0.8);
+      setQrWidth(eightyPercentWidth);
+    } else {
+      setQrWidth(undefined);
+    }
+  }, [width]);
 
   useEffect(() => {
     if (!canvasRef.current || !value) return;
 
+    const options: QRCodeRenderersOptions = { scale: 2, ...rest };
+    if (qrWidth) options.width = qrWidth;
+
     qrcode.toCanvas(
       canvasRef.current,
       value,
-      { scale: 3, ...rest },
+      options,
       (e) => e && console.error(e)
     );
-  }, [value, rest]);
+  }, [value, rest, qrWidth]);
 
   return (
     <canvas

--- a/src/util/useWindowDimensions.tsx
+++ b/src/util/useWindowDimensions.tsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import { debounce } from "lodash";
+
+const getWindowDimensions = () => {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+};
+
+export const useWindowDimensions = () => {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowDimensions(getWindowDimensions());
+    };
+
+    const debouncedHandleResize = debounce(handleResize, 500);
+
+    window.addEventListener("resize", debouncedHandleResize);
+    return () => window.removeEventListener("resize", debouncedHandleResize);
+  }, []);
+
+  return windowDimensions;
+};

--- a/src/util/useWindowDimensions.tsx
+++ b/src/util/useWindowDimensions.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from "react";
 import { debounce } from "lodash";
 
-const getWindowDimensions = () => {
+interface WindowDimension {
+  width: number;
+  height: number;
+}
+
+const getWindowDimensions = (): WindowDimension => {
   const { innerWidth: width, innerHeight: height } = window;
   return {
     width,
@@ -9,13 +14,13 @@ const getWindowDimensions = () => {
   };
 };
 
-export const useWindowDimensions = () => {
+export const useWindowDimensions = (): WindowDimension => {
   const [windowDimensions, setWindowDimensions] = useState(
     getWindowDimensions()
   );
 
   useEffect(() => {
-    const handleResize = () => {
+    const handleResize = (): void => {
       setWindowDimensions(getWindowDimensions());
     };
 


### PR DESCRIPTION
## What does this PR do?
- Create a hook to get viewport width and height
- When viewport width is <300px, forcefully set the QR code width to 80% of viewport width. This is made possible because the `width` option takes precedence over the `scale` option: https://github.com/soldair/node-qrcode#width