### PR TITLE
feat: update sdd codes and description

### DIFF
--- a/static/SDD.mapping.json
+++ b/static/SDD.mapping.json
@@ -1,7 +1,7 @@
 {
     "3339641000133109": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL COVID-19 Vaccine [Tozinameran] Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection"
     },
     "3407851000133103": {
         "short_name": "MODERNA",
@@ -57,7 +57,7 @@
     },
     "878571000133104": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL (AGE 5 TO <12 YEARS) COVID-19 Vaccine [Tozinameran] 100 microgram/ 10 dose Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY (AGE 5 TO <12 YEARS) COVID-19 Vaccine [Tozinameran] 100 microgram/ 10 dose Injection"
     },
     "991221000133108": {
         "short_name": "COVOVAX",
@@ -101,7 +101,7 @@
     },
     "2090011000133109": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Tozinameran] 30 microgram/ 10 dose Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Tozinameran] 30 microgram/ 10 dose Injection"
     },
     "114759641000133104": {
         "short_name": "PFIZER",
@@ -121,6 +121,6 @@
     }, 
     "3356751000133109": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL COVID-19 Vaccine [Tozinameran] 180 microgram/ 6 dose Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] 180 microgram/ 6 dose Injection"
     }
 }

--- a/static/SDD.mapping.json
+++ b/static/SDD.mapping.json
@@ -117,8 +117,8 @@
     },
     "114759211000133101": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] 180 microgram/ 6 dose Injection",
-    }, 
+        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] 180 microgram/ 6 dose Injection"
+    },
     "3356751000133109": {
         "short_name": "PFIZER",
         "name": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] 180 microgram/ 6 dose Injection"

--- a/static/SDD.mapping.json
+++ b/static/SDD.mapping.json
@@ -1,7 +1,7 @@
 {
     "3339641000133109": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH COVID-19 Vaccine [Tozinameran] Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL COVID-19 Vaccine [Tozinameran] Injection"
     },
     "3407851000133103": {
         "short_name": "MODERNA",
@@ -57,7 +57,7 @@
     },
     "878571000133104": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY (AGE 5 to <12 YEARS) COVID-19 Vaccine [Tozinameran] 100 microgram/ 10 dose Injection"
+        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL (AGE 5 TO <12 YEARS) COVID-19 Vaccine [Tozinameran] 100 microgram/ 10 dose Injection"
     },
     "991221000133108": {
         "short_name": "COVOVAX",
@@ -101,6 +101,26 @@
     },
     "2090011000133109": {
         "short_name": "PFIZER",
-        "name": "PFIZER-BIONTECH/COMIRNATY (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Tozinameran]"
+        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Tozinameran] 30 microgram/ 10 dose Injection"
+    },
+    "114759641000133104": {
+        "short_name": "PFIZER",
+        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] Injection"
+    },
+    "114760551000133102": {
+        "short_name": "PFIZER",
+        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Raxtozinameran] 30 microgram/ 10 dose Injection"
+    },
+    "114765911000133100": {
+        "short_name": "PFIZER",
+        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 (AGE 5 TO <12 YEARS) COVID-19 Vaccine [Raxtozinameran] 60 microgram/ 6 dose Injection"    
+    },
+    "114759211000133101": {
+        "short_name": "PFIZER",
+        "name": "PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] 180 microgram/ 6 dose Injection",
+    }, 
+    "3356751000133109": {
+        "short_name": "PFIZER",
+        "name": "PFIZER-BIONTECH/COMIRNATY ORIGINAL COVID-19 Vaccine [Tozinameran] 180 microgram/ 6 dose Injection"
     }
 }


### PR DESCRIPTION
## Context
There are new SDD codes and revised SDD descriptions for COVID-19 Vaccines as of 29 September 2023

## What this PR does
- Add in 4 new `PFIZER-BIONTECH/COMIRNATY` SDD codes
- Add in 1 former code `3356751000133109`
- Update `PFIZER-BIONTECH/COMIRNATY` description to their "Former SDD Preferred Term" instead of "Revised SDD Preferred Term" because CMB is mapping to the former term

---
**Note:**
CMB will map the following to the base ID `3339641000133109` (PFIZER-BIONTECH/COMIRNATY) for those above 5 years:
- `114759641000133104` (PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] Injection)
- `114759211000133101` (PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 COVID-19 Vaccine [Raxtozinameran] 180 microgram/ 6 dose Injection)
- `114765911000133100` (PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 (AGE 5 TO <12 YEARS) COVID-19 Vaccine [Raxtozinameran] 60 microgram/ 6 dose Injection)

For the infant formula `114760551000133102` (PFIZER-BIONTECH/COMIRNATY OMICRON XBB.1.5 (AGE 6 MONTHS TO <5 YEARS) COVID-19 Vaccine [Raxtozinameran] 30 microgram/ 10 dose Injection) , they will map to base ID `2090011000133109` for Pfizer infant